### PR TITLE
Clarify when to disable spies while building Pyroscope locally.

### DIFF
--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -77,8 +77,8 @@ make assets-watch
 make build
 ```
 
-:::caution
-if this command fails try building the binary without third party integrations:
+:::note
+If you have skipped step 3 (build third-party dependencies), you'll need to build the binary without third party integrations:
 ```
 ENABLED_SPIES=none make build
 ```


### PR DESCRIPTION
The docs suggest it should be tried without spies if there's any kind
of failure, but it should only fail if the third party dependencies
have not been built.