### PR TITLE
developer guide improvements

### DIFF
--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -37,7 +37,7 @@ npm install -g yarn
 
 ## Building pyroscope locally
 
-To start developing you need to know a few commands:
+To build pyroscope you need to run a few commands:
 
 
 #### 1. Clone the repo:
@@ -67,7 +67,7 @@ make build-third-party-dependencies
 
 #### 4. Build web assets (JavaScript + SCSS code):
 ```shell
-make assets
+make assets-release
 ```
 
 #### 5. Builds the main binary, puts it in `bin/pyroscope`:
@@ -89,7 +89,7 @@ make server
 
 ---
 
-## Building pyroscope for local development
+## Developing pyroscope
 
 If you're going to be working on pyroscope a lot, consider doing the following:
 


### PR DESCRIPTION
@abeaumont mentioned that `make assets` fail (since it requires the go server), so I replaced for `make assets-release` instead.

The other thing is just making more clear that the first flow is for building pyroscope ONCE (for whatever reason), and the other flow is for when you actively developing.