### PR TITLE
docs: tracing integration

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -35,6 +35,7 @@ This is the easiest way to configure pyroscope. For the list of command line arg
 | no-adhoc-ui | false | Disable the adhoc UI interface. |
 | hide-applications | [] | Please don't use, this will soon be deprecated. |
 | retention | 0s | Sets the maximum amount of time the profiling data is stored for. Data before this threshold is deleted. Disabled by default. |
+| exemplars-retention | 0s | Sets the maximum amount of time profile exemplars are stored for. Data before this threshold is deleted. Disabled by default. |
 | retention-levels | {} | Specifies how long the profiling data is stored per aggregation level. Disabled by default. |
 | tls-certificate-file | "" | Location of TLS Certificate file (.crt). |
 | tls-key-file | "" | Location of TLS Private key file (.key). |
@@ -119,6 +120,9 @@ hide-applications: []
 
 # Sets the maximum amount of time the profiling data is stored for. Data before this threshold is deleted. Disabled by default.
 retention: "0s"
+
+# Sets the maximum amount of time profile exemplars are stored for. Data before this threshold is deleted. Disabled by default.
+exemplars-retention: "0s"
 
 # Specifies how long the profiling data is stored per aggregation level. Disabled by default.
 retention-levels: {}

--- a/docs/integration-golang-pull-mode.mdx
+++ b/docs/integration-golang-pull-mode.mdx
@@ -1,7 +1,7 @@
 ---
 id: integration-golang-pull-mode
-title: Golang Pull Mode
-sidebar_label: Golang (Pull)
+title: Go Pull Mode
+sidebar_label: Pull Mode
 slug: /golang-pull-mode
 description: Pyroscope Golang pull mode
 keywords: [ pyroscope, pull, scrape, discovery, pprof ]

--- a/docs/integration-golang-tracing.mdx
+++ b/docs/integration-golang-tracing.mdx
@@ -1,0 +1,100 @@
+---
+id: integration-golang-tracing
+title: Go Tracing Integration
+sidebar_label: Tracing Integration
+slug: /golang-tracing
+description: Pyroscope Go Tracing Integration
+keywords: [ pyroscope, go, golang, profiling, tracing, opentelemetry, otelpyroscope ]
+---
+
+## OpenTelemetry support
+
+Pyroscope can integrate with distributed tracing systems supporting [**OpenTelemetry**](https://opentelemetry.io/docs/instrumentation/go/getting-started/) standard which allows you to
+link traces with the profiling data, and find specific lines of code related to a performance issue.
+
+:::note
+ * Only CPU profiling is supported at the moment.
+ * We recommend you using Go 1.18 to ensure accurate results.
+ * Because of how sampling profilers work, spans shorter than the sample interval may not be captured. Go CPU profiler probes stack traces 100 times per second, meaning that spans shorter than 10ms may not be captured.
+:::
+
+Go code can be easily instrumented with [otelpyroscope](https://github.com/pyroscope-io/otelpyroscope) package -
+a `TracerProvider` implementation, that annotates profiling data with span IDs which makes it possible to filter
+out profile of a particular trace span in Pyroscope:
+
+```shell
+# Make sure you also upgrade pyroscope server to version 0.14.0 or higher.
+go get github.com/pyroscope-io/otelpyroscope
+```
+
+Now we can create and configure the tracer provider:
+```go
+// Create an exporter that prints traces to stdout.
+exporter, _ := stdouttrace.New(stdouttrace.WithPrettyPrint())
+tp := trace.NewTracerProvider(
+    trace.WithSampler(trace.AlwaysSample()),
+    trace.WithBatcher(exporter),
+)
+defer func() {
+    if err := tp.Shutdown(context.Background()); err != nil {
+        log.Fatal(err)
+    }
+}()
+
+// We wrap the tracer provider to also annotate goroutines with Span ID so
+// that pprof would add corresponding labels to profiling samples.
+otel.SetTracerProvider(otelpyroscope.NewTracerProvider(tp,
+    otelpyroscope.WithAppName("simple.golang.app"),
+    otelpyroscope.WithPyroscopeURL("http://pyroscope-server:4040"),
+    otelpyroscope.WithRootSpanOnly(true),
+    otelpyroscope.WithAddSpanName(true),
+    otelpyroscope.WithProfileURL(true),
+    otelpyroscope.WithProfileBaselineURL(true),
+))
+```
+
+Please notice the `WithRootSpanOnly` option: when enabled, the tracer will annotate only the first span created locally
+(the root span), but the profile will include samples of all the nested spans. This may be helpful in case if the trace
+consists of multiple spans shorter than 10ms and profiler can't collect and annotate samples properly.
+
+Another option that you may find useful is `WithAddSpanName` that controls whether the span name added to profile labels
+automatically. You can find description of all the options in [the package documentation](https://pkg.go.dev/github.com/pyroscope-io/otelpyroscope#Option).
+
+:::important
+If you enable `WithAddSpanName` option, please make sure span names do not contain unique values, for example, a URL.
+Otherwise, this can increase data cardinality and slow down queries.
+:::
+
+Now that we set up the tracer, we can create a new trace from anywhere:
+```go
+ctx, span := otel.Tracer("tracerName").Start(context.Background(), "ExampleSpan")
+defer span.End()
+
+// Your code goes here.
+```
+
+Collected profiles can be viewed in Pyroscope UI using FlameQL:
+ - `simple.golang.app.cpu{profile_id="<spanID>"}` - Shows flamegraph for a particular span.
+ - `simple.golang.app.cpu{span_name="ExampleSpan"}` - Shows aggregated profile for all spans named **ExampleSpan**.
+
+For convenience, the tracer annotates profiled spans with extra attributes:
+ - `pyroscope.profile.id` - is set to span ID to indicate that profile was captured for a span.
+ - `pyroscope.profile.url` - contains the URL to the flamegraph in Pyroscope UI.
+ - `pyroscope.profile.baseline.url` - contains the URL to the baseline comparison view in Pyroscope UI.
+
+## Baseline profiles
+
+A **baseline profile** is an aggregate of all span profiles. For example, consider two exemplars (the number here
+replaces profiling data):
+ - `app.cpu{region="us=east",env="dev",span_name="FetchData",profile_id="abc"}` 100
+ - `app.cpu{region="us=east",env="dev",span_name="FetchData",profile_id="zyx"}` 200
+
+Then, the baseline profile for each of them is:
+ - `app.cpu{region="us=east",env="dev",span_name="FetchData"}` 300
+
+## Examples
+
+Check out the [examples](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing) directory in our repository to
+find a complete example application that demonstrates tracing integration features and learn more 🔥
+ - [Jaeger](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing/jaeger)
+ - [Honeycomb](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing/honeycomb)

--- a/docs/integration-golang.mdx
+++ b/docs/integration-golang.mdx
@@ -4,7 +4,7 @@ title: Go
 sidebar_label: Golang (Push)
 slug: /golang
 description: Pyroscope Go profiling
-keywords: [ pyroscope, go, golang, profiling ]
+keywords: [ pyroscope, go, golang, profiling, tracing, opentelemetry, otelpyroscope ]
 ---
 
 Pyroscope uses the standard `runtime/pprof` package to collect profiling data. Refer to
@@ -171,6 +171,14 @@ For convenience, the tracer annotates profiled spans with extra attributes:
  - `pyroscope.profile.id` - is set to span ID to indicate that profile was captured for a span.
  - `pyroscope.profile.url` - contains the URL to the flamegraph in Pyroscope UI.
  - `pyroscope.profile.baseline.url` - contains the URL to the baseline comparison view in Pyroscope UI.
+
+A **baseline profile** is an aggregate of all span profiles. For example, consider two exemplars (the number here
+replaces profiling data):
+ - `app.cpu{region="us=east",env="dev",span_name="FetchData",profile_id="abc"}` 100
+ - `app.cpu{region="us=east",env="dev",span_name="FetchData",profile_id="zyx"}` 200
+
+Then, the baseline profile for each of them is:
+ - `app.cpu{region="us=east",env="dev",span_name="FetchData"}` 300
 
 You can find a complete example application that demonstrates tracing integration features in our repository:
  - [Jaeger](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing/jaeger)

--- a/docs/integration-golang.mdx
+++ b/docs/integration-golang.mdx
@@ -97,6 +97,85 @@ import _ "net/http/pprof"
 * For information on how to use `net/http/pprof` refer to official [net/http/pprof documentation](https://pkg.go.dev/net/http/pprof).
 * For more information on how to set up pyroscope server to pull data from your applications, refer to [pull mode documentation](/docs/golang-pull-mode).
 
+
+### Tracing integration
+
+Pyroscope can integrate with distributed tracing systems supporting [**OpenTelemetry**](https://opentelemetry.io/docs/instrumentation/go/getting-started/) standard which allows you to
+link traces with the profiling data, and find specific lines of code related to a performance issue.
+
+:::note
+ * Only CPU profiling is supported at the moment.
+ * We recommend you using Go 1.18 to ensure accurate results.
+ * Because of how sampling profilers work, spans shorter than the sample interval may not be captured. Go CPU profiler probes stack traces 100 times per second, meaning that spans shorter than 10ms may not be captured.
+:::
+
+Go code can be easily instrumented with [otelpyroscope](https://github.com/pyroscope-io/otelpyroscope) package -
+a `TracerProvider` implementation, that annotates profiling data with span IDs which makes it possible to filter
+out profile of a particular trace span in Pyroscope:
+
+```shell
+go get github.com/pyroscope-io/otelpyroscope
+```
+
+Now we can create and configure the tracer provider:
+```go
+// Create an exporter that prints traces to stdout.
+exporter, _ := stdouttrace.New(stdouttrace.WithPrettyPrint())
+tp := trace.NewTracerProvider(
+    trace.WithSampler(trace.AlwaysSample()),
+    trace.WithBatcher(exporter),
+)
+defer func() {
+    if err := tp.Shutdown(context.Background()); err != nil {
+        log.Fatal(err)
+    }
+}()
+
+// We wrap the tracer provider to also annotate goroutines with Span ID so
+// that pprof would add corresponding labels to profiling samples.
+otel.SetTracerProvider(otelpyroscope.NewTracerProvider(tp,
+    otelpyroscope.WithAppName("simple.golang.app"),
+    otelpyroscope.WithPyroscopeURL("http://pyroscope-server:4040"),
+    otelpyroscope.WithRootSpanOnly(true),
+    otelpyroscope.WithAddSpanName(true),
+    otelpyroscope.WithProfileURL(true),
+    otelpyroscope.WithProfileBaselineURL(true),
+))
+```
+
+Please notice the `WithRootSpanOnly` option: when enabled, the tracer will annotate only the first span created locally
+(the root span), but the profile will include samples of all the nested spans. This may be helpful in case if the trace
+consists of multiple spans shorter than 10ms and profiler can't collect and annotate samples properly.
+
+Another option that you may find useful is `WithAddSpanName` that controls whether the span name added to profile labels
+automatically. You can find description of all the options in [the package documentation](https://pkg.go.dev/github.com/pyroscope-io/otelpyroscope#Option).
+
+:::important
+If you enable `WithAddSpanName` option, please make sure span names do not contain unique values, for example, a URL.
+Otherwise, this can increase data cardinality and slow down queries.
+:::
+
+Now that we set up the tracer, we can create a new trace from anywhere:
+```go
+ctx, span := otel.Tracer("tracerName").Start(context.Background(), "ExampleSpan")
+defer span.End()
+
+// Your code goes here.
+```
+
+Collected profiles can be viewed in Pyroscope UI using FlameQL:
+ - `simple.golang.app.cpu{profile_id="<spanID>"}` - Shows flamegraph for a particular span.
+ - `simple.golang.app.cpu{span_name="ExampleSpan"}` - Shows aggregateg profile for all spans named **ExampleSpan**.
+
+For convenience, the tracer annotates profiled spans with extra attributes:
+ - `pyroscope.profile.id` - is set to span ID to indicate that profile was captured for a span.
+ - `pyroscope.profile.url` - contains the URL to the flamegraph in Pyroscope UI.
+ - `pyroscope.profile.baseline.url` - contains the URL to the baseline comparison view in Pyroscope UI.
+
+You can find a complete example application that demonstrates tracing integration features in our repository:
+ - [Jaeger](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing/jaeger)
+ - [Honeycomb](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing/honeycomb)
+
 ### Examples
 
 Check out the [examples](https://github.com/pyroscope-io/pyroscope/tree/main/examples/golang-push) directory in our repository to learn more 🔥

--- a/docs/integration-golang.mdx
+++ b/docs/integration-golang.mdx
@@ -1,10 +1,10 @@
 ---
 id: integration-golang
 title: Go
-sidebar_label: Golang (Push)
+sidebar_label: Client
 slug: /golang
 description: Pyroscope Go profiling
-keywords: [ pyroscope, go, golang, profiling, tracing, opentelemetry, otelpyroscope ]
+keywords: [ pyroscope, go, golang, profiling ]
 ---
 
 Pyroscope uses the standard `runtime/pprof` package to collect profiling data. Refer to
@@ -97,92 +97,11 @@ import _ "net/http/pprof"
 * For information on how to use `net/http/pprof` refer to official [net/http/pprof documentation](https://pkg.go.dev/net/http/pprof).
 * For more information on how to set up pyroscope server to pull data from your applications, refer to [pull mode documentation](/docs/golang-pull-mode).
 
+### Tracing Integraiton
 
-### Tracing integration
-
-Pyroscope can integrate with distributed tracing systems supporting [**OpenTelemetry**](https://opentelemetry.io/docs/instrumentation/go/getting-started/) standard which allows you to
-link traces with the profiling data, and find specific lines of code related to a performance issue.
-
-:::note
- * Only CPU profiling is supported at the moment.
- * We recommend you using Go 1.18 to ensure accurate results.
- * Because of how sampling profilers work, spans shorter than the sample interval may not be captured. Go CPU profiler probes stack traces 100 times per second, meaning that spans shorter than 10ms may not be captured.
-:::
-
-Go code can be easily instrumented with [otelpyroscope](https://github.com/pyroscope-io/otelpyroscope) package -
-a `TracerProvider` implementation, that annotates profiling data with span IDs which makes it possible to filter
-out profile of a particular trace span in Pyroscope:
-
-```shell
-go get github.com/pyroscope-io/otelpyroscope
-```
-
-Now we can create and configure the tracer provider:
-```go
-// Create an exporter that prints traces to stdout.
-exporter, _ := stdouttrace.New(stdouttrace.WithPrettyPrint())
-tp := trace.NewTracerProvider(
-    trace.WithSampler(trace.AlwaysSample()),
-    trace.WithBatcher(exporter),
-)
-defer func() {
-    if err := tp.Shutdown(context.Background()); err != nil {
-        log.Fatal(err)
-    }
-}()
-
-// We wrap the tracer provider to also annotate goroutines with Span ID so
-// that pprof would add corresponding labels to profiling samples.
-otel.SetTracerProvider(otelpyroscope.NewTracerProvider(tp,
-    otelpyroscope.WithAppName("simple.golang.app"),
-    otelpyroscope.WithPyroscopeURL("http://pyroscope-server:4040"),
-    otelpyroscope.WithRootSpanOnly(true),
-    otelpyroscope.WithAddSpanName(true),
-    otelpyroscope.WithProfileURL(true),
-    otelpyroscope.WithProfileBaselineURL(true),
-))
-```
-
-Please notice the `WithRootSpanOnly` option: when enabled, the tracer will annotate only the first span created locally
-(the root span), but the profile will include samples of all the nested spans. This may be helpful in case if the trace
-consists of multiple spans shorter than 10ms and profiler can't collect and annotate samples properly.
-
-Another option that you may find useful is `WithAddSpanName` that controls whether the span name added to profile labels
-automatically. You can find description of all the options in [the package documentation](https://pkg.go.dev/github.com/pyroscope-io/otelpyroscope#Option).
-
-:::important
-If you enable `WithAddSpanName` option, please make sure span names do not contain unique values, for example, a URL.
-Otherwise, this can increase data cardinality and slow down queries.
-:::
-
-Now that we set up the tracer, we can create a new trace from anywhere:
-```go
-ctx, span := otel.Tracer("tracerName").Start(context.Background(), "ExampleSpan")
-defer span.End()
-
-// Your code goes here.
-```
-
-Collected profiles can be viewed in Pyroscope UI using FlameQL:
- - `simple.golang.app.cpu{profile_id="<spanID>"}` - Shows flamegraph for a particular span.
- - `simple.golang.app.cpu{span_name="ExampleSpan"}` - Shows aggregateg profile for all spans named **ExampleSpan**.
-
-For convenience, the tracer annotates profiled spans with extra attributes:
- - `pyroscope.profile.id` - is set to span ID to indicate that profile was captured for a span.
- - `pyroscope.profile.url` - contains the URL to the flamegraph in Pyroscope UI.
- - `pyroscope.profile.baseline.url` - contains the URL to the baseline comparison view in Pyroscope UI.
-
-A **baseline profile** is an aggregate of all span profiles. For example, consider two exemplars (the number here
-replaces profiling data):
- - `app.cpu{region="us=east",env="dev",span_name="FetchData",profile_id="abc"}` 100
- - `app.cpu{region="us=east",env="dev",span_name="FetchData",profile_id="zyx"}` 200
-
-Then, the baseline profile for each of them is:
- - `app.cpu{region="us=east",env="dev",span_name="FetchData"}` 300
-
-You can find a complete example application that demonstrates tracing integration features in our repository:
- - [Jaeger](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing/jaeger)
- - [Honeycomb](https://github.com/pyroscope-io/pyroscope/tree/main/examples/tracing/honeycomb)
+Pyroscope can integrate with distributed tracing systems supporting OpenTelemetry standard which allows you to link
+traces with the profiling data, and find specific lines of code related to a performance issue. For more information,
+refer to [tracing integration documentation](/docs/golang-tracing).
 
 ### Examples
 

--- a/docs/retention.mdx
+++ b/docs/retention.mdx
@@ -17,6 +17,12 @@ You can configure a specific period of time for which data will be stored in the
 retention: 720h # 30 days
 ```
 
+Note that Pyroscope uses a separate storage for exemplars created using tracing integration, and allows configuring
+the retention period for them separately:
+```yaml
+exemplars-retention: 72h # 3 days
+```
+
 :::note
 The standard [Go time duration format](https://pkg.go.dev/time#ParseDuration) is used.
 :::

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,8 +39,16 @@ module.exports = {
           collapsed: false,
           items: [
             "agent-overview",
-            "integration-golang",
-            "integration-golang-pull-mode",
+            {
+              type: "category",
+              label: "Go",
+              collapsed: false,
+              items: [
+                "integration-golang",
+                "integration-golang-tracing",
+                "integration-golang-pull-mode",
+              ],
+            },
             "integration-python",
             "integration-ebpf",
             "integration-java",


### PR DESCRIPTION
The PR adds the documentation for [otelpyroscope](https://github.com/pyroscope-io/otelpyroscope).

The Go pages were also reorganized:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/12090599/159929987-143b2e27-fb99-4009-821f-dc8a9b69550d.png">

I originally put this into the main Go page but that didn't look good (see https://github.com/pyroscope-io/docs/pull/53/commits/dd74aa69e326dfcb2f9c6cd75e9e8a6e5e95ec00). Alternatively, we can create a separate page (say, under **Using Pyroscope**) that would list tracing integration packages. Please tell me what you think about this.

/cc @Rperry2174 @petethepig 