### PR TITLE
docs: extend ingestion documentation.

### DIFF
--- a/docs/server-api-reference.mdx
+++ b/docs/server-api-reference.mdx
@@ -44,30 +44,73 @@ an API key.
 
 Currently there's just one endpoint: `POST /ingest`. It takes profile data in request body and metadata as query params.
 
-It takes mutliple query parameters:
+It takes multiple query parameters:
 
-| Name         | Description                             | Notes                          |
-| :----------- | :-------------------------------------- | :----------------------------- |
-| `name`       | Application Name                        | required, should be url-encoded|
-| `from`       | UNIX time of when the profiling started | required                       |
-| `until`      | UNIX time of when the profiling stopped | required                       |
-| `format`     | format of the profiling data            | optional (default is `folded`) |
-| `sampleRate` | sample rate used in Hz                  | optional (default is 100 Hz)   |
-| `spyName`    | name of the spy used                    | optional                       |
-
-Request body contains the profiling data.
-
-* `format`. Pyroscope supports different formats, the simplest one is `folded`. With this format you put one stacktrace per line with a number of samples you've captured for that particular stacktrace, for example:
-
-```
-foo;bar 100
-foo;baz 200
-```
+| Name               | Description                             | Notes                           |
+|:-------------------|:----------------------------------------|:--------------------------------|
+| `name`             | application name                        | required, should be url-encoded |
+| `from`             | UNIX time of when the profiling started | required                        |
+| `until`            | UNIX time of when the profiling stopped | required                        |
+| `format`           | format of the profiling data            | optional (default is `folded`)  |
+| `sampleRate`       | sample rate used in Hz                  | optional (default is 100 Hz)    |
+| `spyName`          | name of the spy used                    | optional                        |
+| `units`            | name of the profiling data unit         | optional (default is `samples`  |
+| `aggregrationType` | type of aggregration to merge profiles  | optional (default is `sum`)     |
 
 * `name` specifies application name. It may be specified in the fully qualified application name notation as described in [the specification](/docs/flameql#notation). For example:
 ```
 my.awesome.app.cpu{env=staging,region=us-west-1}
 ```
+
+Request body contains the profiling data, and request header `Content-Type` may also be alongside `format` to determine profiling data format.
+
+Some of the query parameters depend on the format of profiling data. Pyroscope currently supports three major ingestion formats.
+
+#### Formats with a single profile type.
+
+Most simple ingestion formats send a single type of profiling data and don't usually support any metadata within the format to indicate which kind of data they are sending.
+In these cases, all the metadata is taken from the query parameters, and the format itself is defined by a combination of both `from` query parameter and `Content-Type` body header.
+The formats that work this way are:
+
+* `folded`. This is the default format. With this format you put one stacktrace per line with a number of samples you've captured for that particular stacktrace, for example:
+```
+foo;bar 100
+foo;baz 200
+```
+* `trie`. A `Content-Type` set to `binary/octet-stream+trie` and a `format` set to `trie` indicates that profile data is sent in this format.
+  This format uses a stacktrace trie and variable-length integers to serialize data in a highly space-optimized way. It's not recommended for third-party integrations.
+* `tree` A `Content-Type` set to `binary/octet-stream+tree` and a `format` set to `tree` indicates that profile data is sent in this format.
+  This format uses a stacktrace tree and variable-length integers to serialize data in an efficient way that matches Pyroscope's internal tree representation. It's not recommended for third-party integrations.
+* `lines` A `format` set to `lines` indicates that profile data is sent in this format. This format is similar to `folded`, except there's no number of samples per stacktrace but a single line per sample, for example:
+```
+foo;bar
+foo;bar
+foo;baz
+foo;bar
+```
+  
+#### pprof format
+
+TBD
+
+#### JFR format
+
+This is the [Java Flight Recorder](https://openjdk.java.net/jeps/328) format, typically used by JVM-based profilers, also supported by [our Java integration](https://github.com/pyroscope-io/pyroscope-java#jfr-format-and-multiple-event-support).
+
+When this format is used, some of the query parameters behave slightly different:
+* `format` should be set to `jfr`.
+* `name` contains the _prefix_ of the application name. Since a single request may contain multiple profile types, the final application name is created concatenating this prefix and the profile type.
+* `units` is ignored, and the actual units depends on the profile types available in the data.
+* `aggregationType` is ignored, and the actual aggregation type depends on the profile types available in the data.
+
+JFR ingestion support uses the profile metadata to determine which profile types are included, which depend on the kind of profiling being done. Currently supported profile types include:
+* `cpu` samples, which includes only profiling data from runnable threads.
+* `itimer` samples, similar to `cpu` profiling.
+* `wall` samples, which includes samples from any threads independently of their state. 
+* `alloc_in_new_tlab_objects`, which indicates the number of new TLAB objects created.
+* `alloc_in_new_tlab_bytes`, which indicates the size in bytes of new TLAB objects created.
+* `alloc_outside_tlab_objects`, which indicates the number of new allocated objects outside any TLAB.
+* `alloc_in_new_tlab_bytes`, which indicates the size in bytes of new allocated objects outside any TLAB.
 
 #### Examples
 

--- a/docs/server-api-reference.mdx
+++ b/docs/server-api-reference.mdx
@@ -12,9 +12,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-## HTTP API
+# HTTP API Reference
 
-### Authentication
+## Authentication
 
 When Pyroscope Server [authentication providers](auth-overview.mdx) are configured,
 API clients should provide a **Bearer** authentication token in the **Authorization** header, like this:
@@ -40,7 +40,7 @@ an API key.
 [agent authentication](api-key-authentication.mdx/#authenticate-agents-with-an-api-key) paragraph for details.
 :::
 
-### Ingestion
+## Ingestion
 
 Currently there's just one endpoint: `POST /ingest`. It takes profile data in request body and metadata as query params.
 
@@ -66,53 +66,108 @@ Request body contains the profiling data, and request header `Content-Type` may 
 
 Some of the query parameters depend on the format of profiling data. Pyroscope currently supports three major ingestion formats.
 
-#### Formats with a single profile type.
+### Text Formats
 
-Most simple ingestion formats send a single type of profiling data and don't usually support any metadata within the format to indicate which kind of data they are sending.
-In these cases, all the metadata is taken from the query parameters, and the format itself is defined by a combination of both `from` query parameter and `Content-Type` body header.
+Most simple ingestion formats send a single type of profiling data (for example, `cpu` samples) and don't usually support any metadata (e.g labels) within the format to indicate which kind of data they are sending.
+In these cases, all the metadata is taken from the query parameters, and the format itself is defined by `format` query parameter.
 The formats that work this way are:
 
-* `folded`. This is the default format. With this format you put one stacktrace per line with a number of samples you've captured for that particular stacktrace, for example:
+* `folded`. Some software also call this format `collapsed`. This is the default format. With this format you put one stacktrace per line with a number of samples you've captured for that particular stacktrace, for example:
 ```
 foo;bar 100
 foo;baz 200
 ```
-* `trie`. A `Content-Type` set to `binary/octet-stream+trie` and a `format` set to `trie` indicates that profile data is sent in this format.
-  This format uses a stacktrace trie and variable-length integers to serialize data in a highly space-optimized way. It's not recommended for third-party integrations.
-* `tree` A `Content-Type` set to `binary/octet-stream+tree` and a `format` set to `tree` indicates that profile data is sent in this format.
-  This format uses a stacktrace tree and variable-length integers to serialize data in an efficient way that matches Pyroscope's internal tree representation. It's not recommended for third-party integrations.
-* `lines` A `format` set to `lines` indicates that profile data is sent in this format. This format is similar to `folded`, except there's no number of samples per stacktrace but a single line per sample, for example:
+* `lines` — This format is similar to `folded`, except there's no number of samples per stacktrace but a single line per sample, for example:
 ```
 foo;bar
 foo;bar
 foo;baz
 foo;bar
 ```
-  
-#### pprof format
 
-TBD
+### pprof format
 
-#### JFR format
+:::info
+Support for `pprof` format is available starting with version `0.14.0`
+:::
+
+
+`pprof` is a binary profiling data format popular in many languages, especially in the Go ecosystem.
+
+When this format is used, some of the query parameters behave slightly different:
+* `format` should be set to `pprof`.
+* `name` contains the _prefix_ of the application name. Since a single request may contain multiple profile types, the final application name is created concatenating this prefix and the profile type. For example, if you send cpu profiling data and set `name` to `my-app{}`, it will appear in pyroscope as `my-app.cpu{}`.
+* `units`, `aggregationType` and `sampleRate` are ignored, and the actual values depends on the profile types available in the data (see the next section, "Sample Type Configuration").
+
+#### Sample Type Configuration
+
+Out of the box Pyroscope server supports [default Go profile types](https://github.com/pyroscope-io/pyroscope/blob/main/pkg/storage/tree/pprof.go#L37-L75) (`cpu`, `inuse_objects`, `inuse_space`, `alloc_objects`, `alloc_space`). When working with other software that generates data in pprof format you may have to provide a custom sample type configuration for pyroscope to be able to parse the data properly.
+
+In order to ingest pprof data with a custom sample type configuration, you have to make the following changes to your requests:
+* use an HTTP form (`multipart/form-data`) Content-Type.
+* send the profile data in a form file field called `profile`.
+* send the sample type configuration in a form file field called `sample_type_config`.
+
+Sample type configuration is a JSON object that looks like this:
+
+```json
+{
+  "inuse_space": { // "inuse_space" here is the internal pprof type name
+    "units": "bytes",
+    "aggregation": "average",
+    "display-name": "inuse_space_bytes",
+    "sampled": false,
+  },
+  // pprof supports multiple profiles types in one file,
+  //   so there can be multiple of these objects
+}
+```
+
+
+Here's a description of sample type configuration fields:
+
+* `units`
+  * Supported values: `samples`, `objects`, `bytes`
+  * Description: This will change the units shown on the frontend. `samples` = cpu samples, `objects` = objects in RAM, `bytes` = bytes in RAM
+* `display-name`
+  * Supported values: any string
+  * Description: this becomes a suffix of app name, for example `my-app.inuse_space_bytes`
+* `aggregation`
+  * Supported values: `sum`, `average`
+  * Description: This changes how data is aggregated when shown on the frontend. use `sum` for data that you want to sum over time (e.g cpu samples, memory allocations), use `average` for data that you want to average over time (e.g. memory memory in-use objects)
+* `sampled`
+  * Supported values: `true` / `false`
+  * Description: This parameter defines if sample rate (specified in pprof file) is going to be taken into account or not. Set this to `true` for sampled events (e.g CPU samples), set it to `false` for memory profiles.
+
+
+Refer to [the sample type configuration source code](https://github.com/pyroscope-io/pyroscope/blob/c45855676a4f5d1f98ce1e0d1217755b0417f9c9/pkg/storage/tree/pprof.go#L7-L13) for more details.
+
+
+### JFR format
+
+:::info
+Support for `JFR` format is available starting with version `0.14.0`
+:::
+
 
 This is the [Java Flight Recorder](https://openjdk.java.net/jeps/328) format, typically used by JVM-based profilers, also supported by [our Java integration](https://github.com/pyroscope-io/pyroscope-java#jfr-format-and-multiple-event-support).
 
 When this format is used, some of the query parameters behave slightly different:
 * `format` should be set to `jfr`.
-* `name` contains the _prefix_ of the application name. Since a single request may contain multiple profile types, the final application name is created concatenating this prefix and the profile type.
+* `name` contains the _prefix_ of the application name. Since a single request may contain multiple profile types, the final application name is created concatenating this prefix and the profile type. For example, if you send cpu profiling data and set `name` to `my-app{}`, it will appear in pyroscope as `my-app.cpu{}`.
 * `units` is ignored, and the actual units depends on the profile types available in the data.
 * `aggregationType` is ignored, and the actual aggregation type depends on the profile types available in the data.
 
 JFR ingestion support uses the profile metadata to determine which profile types are included, which depend on the kind of profiling being done. Currently supported profile types include:
 * `cpu` samples, which includes only profiling data from runnable threads.
 * `itimer` samples, similar to `cpu` profiling.
-* `wall` samples, which includes samples from any threads independently of their state. 
+* `wall` samples, which includes samples from any threads independently of their state.
 * `alloc_in_new_tlab_objects`, which indicates the number of new TLAB objects created.
 * `alloc_in_new_tlab_bytes`, which indicates the size in bytes of new TLAB objects created.
 * `alloc_outside_tlab_objects`, which indicates the number of new allocated objects outside any TLAB.
 * `alloc_in_new_tlab_bytes`, which indicates the size in bytes of new allocated objects outside any TLAB.
 
-#### Examples
+### Examples
 
 Here's a sample code that uploads a very simple profile to pyroscope:
 <Tabs
@@ -151,7 +206,7 @@ requests.post(url, data = data)
   </TabItem>
 </Tabs>
 
-### Adhoc support
+## Adhoc support
 
 In [adhoc profiling mode](https://pyroscope.io/blog/pyroscope-adhoc-profiling/) the way Pyroscope works with integrations that use
 the HTTP API is as follows:


### PR DESCRIPTION
- Add missing query parameters
- Explain the different supported formats and how to signal them in
  the request.

pprof is TBD.