### PR TITLE
Docs: Update  developer guide to include make dev troubleshoot notice

### DIFF
--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -198,6 +198,10 @@ make dev
 ```
 It builds assets in watch mode + builds the main binary and starts the server all on one command.
 
+:::note
+Are you getting a `bad file descriptor` or `too many open files` error? Then run this command: `ulimit -S -n 2048`. Once you do that, run the `make dev` command again. Please note that the ulimit shell command only works on Unix like OS (e.g. Linux/macOS).
+:::
+
 ### Windows
 
 1. Install [Docker](https://www.docker.com/products/docker-desktop).

--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -199,7 +199,7 @@ make dev
 It builds assets in watch mode + builds the main binary and starts the server all on one command.
 
 :::note
-If you are getting a `bad file descriptor` or `too many open files` error, then run this command: `ulimit -S -n 2048`. Once you do that, run the `make dev` command again. Please note that the ulimit shell command only works on Unix like OS (e.g. Linux/macOS).
+If you are getting a `bad file descriptor` or `too many open files` error, then run this command: `ulimit -S -n 2048`. Once you do that, run the `make dev` command again. Please note that the ulimit shell command only works on Unix-like OS (e.g. Linux/macOS).
 :::
 
 ### Windows

--- a/docs/developer-guide.mdx
+++ b/docs/developer-guide.mdx
@@ -199,7 +199,7 @@ make dev
 It builds assets in watch mode + builds the main binary and starts the server all on one command.
 
 :::note
-Are you getting a `bad file descriptor` or `too many open files` error? Then run this command: `ulimit -S -n 2048`. Once you do that, run the `make dev` command again. Please note that the ulimit shell command only works on Unix like OS (e.g. Linux/macOS).
+If you are getting a `bad file descriptor` or `too many open files` error, then run this command: `ulimit -S -n 2048`. Once you do that, run the `make dev` command again. Please note that the ulimit shell command only works on Unix like OS (e.g. Linux/macOS).
 :::
 
 ### Windows


### PR DESCRIPTION
While following the developer guide, I noticed `make dev` outputs a `bad file descriptor` error. I did some troubleshooting and noticed it was a result of a UNIX settings under the hood.

So basically, OS (mac included) have settings that limit the number of files and processes that are allowed to be open. On mac, it’s set too low which automatically leads to errors such as `bad file descriptor` or `too many files open`. 

To fix the issue, I used the `ulimit shell` command to increase the number of files/processes allowed on my machine.