### PR TITLE
Adds "how to embed a flamegraph" blog post

### DIFF
--- a/blog/debug-python-with-pyroscope.mdx
+++ b/blog/debug-python-with-pyroscope.mdx
@@ -22,6 +22,7 @@ In fact, Netflix performance architect Brendan Gregg mentioned that decreasing C
 
 So when you see a graph of CPU utilization that looks like this:
 ![image](https://user-images.githubusercontent.com/23323466/105662478-aa40ce80-5e84-11eb-800a-57735c688fc9.png)
+<!--truncate-->
 
 During the period of 100% CPU utilization, you can assume:
 - End-users are having a frustrating experience (i.e. App / Website is loading slow)

--- a/blog/how-to-embed-a-flamegraph.mdx
+++ b/blog/how-to-embed-a-flamegraph.mdx
@@ -32,10 +32,12 @@ We recently released an update to flamegraph.com that makes it easy to embed fla
 ## Example Embedded Flamegraph
 After you've pasted the embed code snippet into your blog or website you'll see a flamegraph that looks like this:
 <iframe frameBorder="0" width="100%" height="400" src="https://flamegraph.com/share/a8c6e7a9-f360-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
+<center style={{margin:"10px 20px 20px"}}><i>Try interacting with flamegraph to better understand what's happening in this application</i></center>
 
 ## Example embedded Diff Flamegraph
 Diff flamegraphs show the diff between two flamegraphs and look like this:
 <iframe frameBorder="0" width="100%" height="400" src="https://flamegraph.com/share/6afa6df7-f362-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
+<center style={{margin:"10px 20px 20px"}}><i>Try interacting with this diff flamegraph to better understand this diff between two flamegraphs</i></center>
 
 ## How to upload a flamegraph to flamegraph.com
 There are three main ways you can upload a flamegraph to flamegraph.com. 

--- a/blog/how-to-embed-a-flamegraph.mdx
+++ b/blog/how-to-embed-a-flamegraph.mdx
@@ -1,6 +1,8 @@
 ---
 title: How to embed a Flamegraph on your website or blog
+description: Learn how to embed a Flamegraph on your website or blog
 sidebar_label: How to embed a Flamegraph on your website
+image: https://user-images.githubusercontent.com/23323466/175955981-fbf8f818-9c55-4cfa-b55e-2e851e344650.png
 slug: /how-to-embed-a-flamegraph
 date: "2022-06-27"
 
@@ -9,13 +11,13 @@ authors:
     url: https://github.com/Rperry2174
     image_url: https://avatars.githubusercontent.com/u/23323466?v=4
 
-tags: [flamegraphs, profiling, embed]
+tags: [embed, upload, flamegraphs, profiling]
 ---
 
 ## Stop screenshotting Flamegraphs and start embedding them
-After several blog posts where we featured flamegraphs as a key piece of the posts we found that screenshotting pictures of
-flamegraphs didn't have the same impact as when its possible to interact with flamegraphs. Typically a flamegraph is only useful when you're able to click into 
-particular nodes or stack traces to understand the program more deeply.
+Typically a flamegraph is _most_ useful when you're able to click into particular nodes or stack traces to understand the program more deeply.
+After several [blog posts](/blog/profile-continuous-profiler/#performance-optimization-1-caching-the-data-in-a-hash-map) where we featured flamegraphs as a key piece of the posts we found that screenshotting pictures of
+flamegraphs was missing this key functionality compared to being able to interact with flamegraphs.
 
 As a result, we created [flamegraph.com](https://flamegraph.com) to have a place where users can upload, view, and share flamegraphs.
 
@@ -39,11 +41,12 @@ Diff flamegraphs show the diff between two flamegraphs and look like this:
 There are three main ways you can upload a flamegraph to flamegraph.com. 
 
 ### Method 1: Exporting a flamegraph directly from Pyroscope
-There are two main ways to export a flamegraph from Pyroscope. The first is to use the "export" menu located on the flamgraph:
+The first method is to use the "export" menu located on the flamegraph:
 <img width="730" alt="image" src="https://user-images.githubusercontent.com/23323466/175833562-fcdfc088-9377-40dd-a985-f30a5a49dc64.png"></img>
 
 ### Method 2: Profile a static script using `pyroscope adhoc` command
-The second way is to profile a script using the `pyroscope adhoc` command ([example](https://github.com/pyroscope-io/pyroscope/tree/main/examples/adhoc)), export to JSON, and then upload that JSON to flamegraph.com.
+The second method is to profile a script using the `pyroscope adhoc` command ([example](https://github.com/pyroscope-io/pyroscope/tree/main/examples/adhoc)), export to JSON, and then upload that JSON to flamegraph.com.
+This is convenient when you don't need to profile a whole application continuously, but rather would like to see a profile for a specific script.
 ```
 pyroscope adhoc go run adhoc-push.go
 # INFO profiling data has been saved to ~/.pyroscope/pyroscope/adhoc.example.go.alloc_objects-2022-06-23-21-37-29.json 
@@ -51,7 +54,7 @@ pyroscope adhoc go run adhoc-push.go
 This will output a json file which you can then upload to flamegraph.com.
 
 ### Method 3: Upload pre-existing pprof or collapsed files
-Similar to Method 2, if you already havea pprof file or collapsed flamegraph file you can upload it to flamegraph.com by using the drag-and-drop uploader.
+Similar to the json from Method 2, if you already have a pprof file or collapsed flamegraph file you can upload it to flamegraph.com by using the drag-and-drop uploader.
 ![upload_flamegraph](https://user-images.githubusercontent.com/23323466/175833667-7add384e-ebef-4193-b3e9-e2a338419286.gif)
 
 ## Get Featured on the Pyroscope Blog / Twitter!

--- a/blog/how-to-embed-a-flamegraph.mdx
+++ b/blog/how-to-embed-a-flamegraph.mdx
@@ -1,0 +1,61 @@
+---
+title: How to embed a Flamegraph on your website or blog
+sidebar_label: How to embed a Flamegraph on your website
+slug: /how-to-embed-a-flamegraph
+date: "2022-06-27"
+
+authors:
+  - name: Ryan Perry
+    url: https://github.com/Rperry2174
+    image_url: https://avatars.githubusercontent.com/u/23323466?v=4
+
+tags: [flamegraphs, profiling, embed]
+---
+
+## How to embed a Flamegraph on your website or blog
+After several blog posts where we featured flamegraphs as a key piece of the posts we found that screenshotting pictures of
+flamegraphs didn't have the same impact as when its possible to interact with flamegraphs. As a result, we created [flamegraph.com](https://flamegraph.com)
+to have a place where users can upload, view, and share flamegraphs.
+
+We recently released an update to flamegraph.com that solves this problem. To embed a flamegraph on your website/blog you need to:
+
+    1. Upload a flamegraph or flamegraph diff to flamegraph.com
+    2. Click the "Embed" button
+    3. Copy the "Copy" button to copy the embed code snippet
+    4. Paste the embed code snippet into your blog or website
+
+[ gif of embedding a flamegraph ](https://media.giphy.com/media/3o7btLXQZqXqQQQQQQ/giphy.gif)
+
+## Example embedded Flamegraph
+```
+<iframe style="width: 100%; height: auto;min-width: 600px;min-height: 400px;" src="https://flamegraph.com/share/a8c6e7a9-f360-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph" frameBorder="0"></iframe>
+```
+
+## Example ebedded Diff Flamegraph
+```
+# Doesn't work in jsx
+<iframe style="width: 100%; height: auto;min-width: 600px;min-height: 400px;" src="https://flamegraph.com/share/6afa6df7-f362-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph" frameBorder="0"></iframe>
+# Works in jsx
+<iframe frameBorder="0" width="100%" height="auto" src="https://flamegraph.com/share/6afa6df7-f362-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
+```
+## How to upload a flamegraph to flamegraph.com
+There are a couple of different ways you can get a flamegraph to upload to flamegraph.com. 
+
+### Exporting a flamegraph from Pyroscope
+There are two main ways to export a flamegraph from Pyroscope. The first is to use the "export" mmenu located on the flamgraph:
+[ image ]
+
+The second way is to profile a script using the `pyroscope adhoc` command ([example](https://github.com/pyroscope-io/pyroscope/tree/main/examples/adhoc)), export to JSON, and then upload that JSON to flamegraph.com.
+```
+pyroscope adhoc go run adhoc-push.go
+# INFO profiling data has been saved to ~/.pyroscope/pyroscope/adhoc.example.go.alloc_objects-2022-06-23-21-37-29.json 
+```
+then you can upload the JSON file to flamegraph.com
+[ gif ]
+and click the "embed" button as shown above.
+
+
+
+
+
+

--- a/blog/how-to-embed-a-flamegraph.mdx
+++ b/blog/how-to-embed-a-flamegraph.mdx
@@ -18,42 +18,38 @@ flamegraphs didn't have the same impact as when its possible to interact with fl
 to have a place where users can upload, view, and share flamegraphs.
 
 We recently released an update to flamegraph.com that solves this problem. To embed a flamegraph on your website/blog you need to:
+  1. Upload a flamegraph or flamegraph diff to flamegraph.com
+  2. Click the "Embed" button
+  3. Copy the "Copy" button to copy the embed code snippet
+  4. Paste the embed code snippet into your blog or website
 
-    1. Upload a flamegraph or flamegraph diff to flamegraph.com
-    2. Click the "Embed" button
-    3. Copy the "Copy" button to copy the embed code snippet
-    4. Paste the embed code snippet into your blog or website
+![clicking_embed_button_high_res](https://user-images.githubusercontent.com/23323466/175833273-3560b1ac-4182-4b24-bd3c-dd22645158a2.gif)
 
-[ gif of embedding a flamegraph ](https://media.giphy.com/media/3o7btLXQZqXqQQQQQQ/giphy.gif)
+## Example Embedded Flamegraph
+After you've pasted the embed code snippet into your blog or website you'll see a flamegraph that looks like this:
+<iframe frameBorder="0" width="100%" height="400" src="https://flamegraph.com/share/a8c6e7a9-f360-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
 
-## Example embedded Flamegraph
-```
-<iframe style="width: 100%; height: auto;min-width: 600px;min-height: 400px;" src="https://flamegraph.com/share/a8c6e7a9-f360-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph" frameBorder="0"></iframe>
-```
+## Example embedded Diff Flamegraph
+Diff flamegraphs show the diff between two flamegraphs and looks like this:
+<iframe frameBorder="0" width="100%" height="400" src="https://flamegraph.com/share/6afa6df7-f362-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
 
-## Example ebedded Diff Flamegraph
-```
-# Doesn't work in jsx
-<iframe style="width: 100%; height: auto;min-width: 600px;min-height: 400px;" src="https://flamegraph.com/share/6afa6df7-f362-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph" frameBorder="0"></iframe>
-# Works in jsx
-<iframe frameBorder="0" width="100%" height="auto" src="https://flamegraph.com/share/6afa6df7-f362-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
-```
 ## How to upload a flamegraph to flamegraph.com
 There are a couple of different ways you can get a flamegraph to upload to flamegraph.com. 
 
 ### Exporting a flamegraph from Pyroscope
-There are two main ways to export a flamegraph from Pyroscope. The first is to use the "export" mmenu located on the flamgraph:
-[ image ]
+There are two main ways to export a flamegraph from Pyroscope. The first is to use the "export" menu located on the flamgraph:
+<img width="730" alt="image" src="https://user-images.githubusercontent.com/23323466/175833562-fcdfc088-9377-40dd-a985-f30a5a49dc64.png"></img>
 
 The second way is to profile a script using the `pyroscope adhoc` command ([example](https://github.com/pyroscope-io/pyroscope/tree/main/examples/adhoc)), export to JSON, and then upload that JSON to flamegraph.com.
 ```
 pyroscope adhoc go run adhoc-push.go
 # INFO profiling data has been saved to ~/.pyroscope/pyroscope/adhoc.example.go.alloc_objects-2022-06-23-21-37-29.json 
 ```
-then you can upload the JSON file to flamegraph.com
-[ gif ]
-and click the "embed" button as shown above.
+![upload_flamegraph](https://user-images.githubusercontent.com/23323466/175833667-7add384e-ebef-4193-b3e9-e2a338419286.gif)
 
+## Get Featured on the Pyroscope blog!
+We love hearing stories about the ways that people have been able to use profiling, Pyroscope, and/or flamegraphs to solve performance problems.
+If you have a story that you'd like to share with us, please [contact us](mailto:contact@pyroscope.io) or let us know on [slack](https://pyroscope.io/slack) and we'll add it to this blog!
 
 
 

--- a/blog/how-to-embed-a-flamegraph.mdx
+++ b/blog/how-to-embed-a-flamegraph.mdx
@@ -56,7 +56,7 @@ pyroscope adhoc go run adhoc-push.go
 ```
 This will output a json file which you can then upload to flamegraph.com.
 
-### Method 3: Upload pre-existing pprof or collapsed files
+### Method 3: Upload pre-existing `pprof` or `collapsed` files
 Similar to the json from Method 2, if you already have a pprof file or collapsed flamegraph file you can upload it to flamegraph.com by using the drag-and-drop uploader.
 ![upload_flamegraph](https://user-images.githubusercontent.com/23323466/175833667-7add384e-ebef-4193-b3e9-e2a338419286.gif)
 

--- a/blog/how-to-embed-a-flamegraph.mdx
+++ b/blog/how-to-embed-a-flamegraph.mdx
@@ -28,6 +28,7 @@ We recently released an update to flamegraph.com that makes it easy to embed fla
   4. Paste the embed code snippet into your blog or website
 
 ![clicking_embed_button_high_res](https://user-images.githubusercontent.com/23323466/175833273-3560b1ac-4182-4b24-bd3c-dd22645158a2.gif)
+<!--truncate-->
 
 ## Example Embedded Flamegraph
 After you've pasted the embed code snippet into your blog or website you'll see a flamegraph that looks like this:

--- a/blog/how-to-embed-a-flamegraph.mdx
+++ b/blog/how-to-embed-a-flamegraph.mdx
@@ -12,12 +12,14 @@ authors:
 tags: [flamegraphs, profiling, embed]
 ---
 
-## How to embed a Flamegraph on your website or blog
+## Stop screenshotting Flamegraphs and start embedding them
 After several blog posts where we featured flamegraphs as a key piece of the posts we found that screenshotting pictures of
-flamegraphs didn't have the same impact as when its possible to interact with flamegraphs. As a result, we created [flamegraph.com](https://flamegraph.com)
-to have a place where users can upload, view, and share flamegraphs.
+flamegraphs didn't have the same impact as when its possible to interact with flamegraphs. Typically a flamegraph is only useful when you're able to click into 
+particular nodes or stack traces to understand the program more deeply.
 
-We recently released an update to flamegraph.com that solves this problem. To embed a flamegraph on your website/blog you need to:
+As a result, we created [flamegraph.com](https://flamegraph.com) to have a place where users can upload, view, and share flamegraphs.
+
+We recently released an update to flamegraph.com that makes it easy to embed flamegraphs in your blog or website. The steps to embed a flamegraph are:
   1. Upload a flamegraph or flamegraph diff to flamegraph.com
   2. Click the "Embed" button
   3. Copy the "Copy" button to copy the embed code snippet
@@ -30,26 +32,32 @@ After you've pasted the embed code snippet into your blog or website you'll see 
 <iframe frameBorder="0" width="100%" height="400" src="https://flamegraph.com/share/a8c6e7a9-f360-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
 
 ## Example embedded Diff Flamegraph
-Diff flamegraphs show the diff between two flamegraphs and looks like this:
+Diff flamegraphs show the diff between two flamegraphs and look like this:
 <iframe frameBorder="0" width="100%" height="400" src="https://flamegraph.com/share/6afa6df7-f362-11ec-bcfa-beb8fdeeb850/iframe?onlyDisplay=flamegraph"></iframe>
 
 ## How to upload a flamegraph to flamegraph.com
-There are a couple of different ways you can get a flamegraph to upload to flamegraph.com. 
+There are three main ways you can upload a flamegraph to flamegraph.com. 
 
-### Exporting a flamegraph from Pyroscope
+### Method 1: Exporting a flamegraph directly from Pyroscope
 There are two main ways to export a flamegraph from Pyroscope. The first is to use the "export" menu located on the flamgraph:
 <img width="730" alt="image" src="https://user-images.githubusercontent.com/23323466/175833562-fcdfc088-9377-40dd-a985-f30a5a49dc64.png"></img>
 
+### Method 2: Profile a static script using `pyroscope adhoc` command
 The second way is to profile a script using the `pyroscope adhoc` command ([example](https://github.com/pyroscope-io/pyroscope/tree/main/examples/adhoc)), export to JSON, and then upload that JSON to flamegraph.com.
 ```
 pyroscope adhoc go run adhoc-push.go
 # INFO profiling data has been saved to ~/.pyroscope/pyroscope/adhoc.example.go.alloc_objects-2022-06-23-21-37-29.json 
 ```
+This will output a json file which you can then upload to flamegraph.com.
+
+### Method 3: Upload pre-existing pprof or collapsed files
+Similar to Method 2, if you already havea pprof file or collapsed flamegraph file you can upload it to flamegraph.com by using the drag-and-drop uploader.
 ![upload_flamegraph](https://user-images.githubusercontent.com/23323466/175833667-7add384e-ebef-4193-b3e9-e2a338419286.gif)
 
-## Get Featured on the Pyroscope blog!
+## Get Featured on the Pyroscope Blog / Twitter!
 We love hearing stories about the ways that people have been able to use profiling, Pyroscope, and/or flamegraphs to solve performance problems.
 If you have a story that you'd like to share with us, please [contact us](mailto:contact@pyroscope.io) or let us know on [slack](https://pyroscope.io/slack) and we'll add it to this blog!
+And if you have a cool flamegraph then tag us on [twitter](https://twitter.com/PyroscopeIO) and we'd love to share your flamegraphs with our followers!
 
 
 

--- a/blog/profile-continuous-profiler.mdx
+++ b/blog/profile-continuous-profiler.mdx
@@ -21,6 +21,7 @@ For Pyroscope, the difference between push and pull mode is that:
 - **Pull mode**: Pyroscope sends a `GET` request to targets (identified in config file) and the targets return profiling data in the response.
 
 ![push_vs_pull_diagram_07](https://user-images.githubusercontent.com/23323466/149289440-564c6e34-03cb-496d-bddc-faa96d075ced.gif)
+<!--truncate-->
 
 One of the major benefits of pull mode is creating meaningful tags. For example, in Kubernetes workflows you can tag profiles with popular metadata fields:
 - **pod_name**: Name of the pod

--- a/blog/profiling-go-apps-with-pyroscope.mdx
+++ b/blog/profiling-go-apps-with-pyroscope.mdx
@@ -16,6 +16,7 @@ tags: [observability, flamegraphs, profiling, go]
 ## Continuous Profiling for Golang applications
 ### Profiling a Golang Rideshare App with Pyroscope
 ![golang_example_architecture_05_1](https://user-images.githubusercontent.com/23323466/149699777-8f73c459-917d-48c5-b2d8-87560a7bfb11.gif)
+<!--truncate-->
 
 Note: For documentation on Pyroscope's golang integration visit our website for [golang push mode](/docs/golang) or [golang pull mode](/docs/golang-pull-mode)
 ## Background

--- a/blog/profiling-with-pyroscopes-pip-package.mdx
+++ b/blog/profiling-with-pyroscopes-pip-package.mdx
@@ -8,7 +8,7 @@ date: "2021-10-14"
 ### Pyroscope Rideshare Example
 ![python_example_architecture_05_00](https://user-images.githubusercontent.com/23323466/135728737-0c5e54ca-1e78-4c6d-933c-145f441c96a9.gif)
 
-
+<!--truncate-->
 Note: For documentation on the Pyroscope pip package see our [python docs](/docs/python)
 
 ## Background

--- a/blog/profiling-with-pyroscopes-ruby-gem.mdx
+++ b/blog/profiling-with-pyroscopes-ruby-gem.mdx
@@ -7,6 +7,7 @@ date: "2021-10-14"
 
 ### Pyroscope Rideshare Example
 ![ruby_example_architecture_05](https://user-images.githubusercontent.com/23323466/135726784-0c367d3f-c9e5-4e3f-91be-761d4d6d21b1.gif)
+<!--truncate-->
 
 Note: For documentation on the Pyroscope ruby gem  see our [ruby docs](/docs/ruby)
 ## Background

--- a/blog/pyroscope-adhoc-profiling.mdx
+++ b/blog/pyroscope-adhoc-profiling.mdx
@@ -26,6 +26,7 @@ Our goal is to make Pyroscope a one-stop-shop for all profiling needs. That mean
 ### Introducing Adhoc profiling
 
 That being said, we are excited to officially release Adhoc profiling mode for Pyroscope! With adhoc mode, you get all the convenience and simplicity of profiling a script, as well as Pyroscope's stellar visualization and UI functionality.
+<!--truncate-->
 
 
 ### Exporting interactive Flamegraph HTML from Pyroscope Adhoc mode

--- a/blog/visualize-flamegraph-in-grafana.mdx
+++ b/blog/visualize-flamegraph-in-grafana.mdx
@@ -45,6 +45,7 @@ Using Pyroscope in Grafana provides you with complete observability without leav
 It costs nothing to migrate your application profile from Pyroscope’s UI dashboard into Grafana. Simply open Grafana and install both the Pyroscope panel and datasource plugin, and you’re all set!
 
 ![left-right: flamegraph in Pyroscope, flamegraph in Grafana](https://user-images.githubusercontent.com/29557702/171664702-7008acdf-0227-4b54-842a-742ddfdd0686.png)
+<!--truncate-->
 
 ### Single authentication
 Because your profiling data is visualized in Grafana, you can login using just your Grafana credentials. Single authentication reduces the stress of logging into both Grafana and Pyroscope applications to visualize your profiles.

--- a/blog/what-is-a-flamegraph.mdx
+++ b/blog/what-is-a-flamegraph.mdx
@@ -95,10 +95,10 @@ You can read a flamegraph by first understanding its features. They include:
 - Y-axis: The y-axis indicates the depth of the call stack. On Pyroscope, the head/root node is positioned at the top by default. The bottom box (tip of the flame) shows the function call that is on-CPU at the initial point of stack trace collection.
 - Background color: The colors for profiles are generally not significant. They are distributed at random to distinguish between function calls. This helps the eye differentiate one profile from the other.
 
-### Playground
+### Interactive Playground
 With everything you've learned so far about flamegraphs, feel free to play around and interpret this interactive flamegraph embedded below.
 
-<iframe src="https://flamegraph.com/share/158a2160-d06b-11ec-9a10-76ec5fdc56e3/iframe" height="600" width="100%"></iframe>
+<iframe src="https://flamegraph.com/share/158a2160-d06b-11ec-9a10-76ec5fdc56e3/iframe?onlyDisplay=flamegraph" height="600" width="100%"></iframe>
 
 ### Summary
 Now that you’ve learned about flamegraphs and how to use them, I encourage you to take a bold step in making performance profiling a priority in your observability journey.

--- a/blog/what-is-a-flamegraph.mdx
+++ b/blog/what-is-a-flamegraph.mdx
@@ -27,6 +27,7 @@ In this article, I will introduce you to flamegraphs, how to use them, how to re
 A flamegraph is a complete visualization of hierarchical data (e.g stack traces, file system contents, etc) with a metric, typically resource usage, attached to the data. Flamegraphs were originally invented by Brendan Gregg. He was inspired by the inability to view, read, and understand stack traces using the regular profilers to debug performance issues. The flamegraph was created to fix this exact problem. 
 
 Flamegraphs allow you to view a call stack in a much more visual way. They give you insight into your code performance and allow you to debug efficiently by drilling down to the origin of a bug, thereby increasing the performance of your application.
+<!--truncate-->
 
 :::note
 Technically, a _flamegraph_ has it's root at the bottom and child nodes are shown above their parents while an _icicle graph_ has it's root at the top and child nodes are shown below their parents. 
@@ -43,13 +44,10 @@ Flamegraphs are generated as a by-product of software profilers. They are repres
 ### Example use cases for flamegraphs
 Flamegraphs are often seen as more of a high level or abstract concept, so here are some situations where flamegraphs would be useful.
 
-
-
 #### Using flamegraphs during pager duty response
 Imagine a scenario where you’re the only engineer in your team that is on-call for the week. Days passed and thankfully, you don’t get any outage alert. On the last day of your on-call, you get a pager duty alert showing a spike in latency in the US-east region. You start by checking the metrics and then logs. In the course of your investigation, you notice the problems go even deeper in the stack.
 
 In a scenario like this, you begin to find ways to visualize CPU usage and identify what’s consuming your CPU resource the most. That is exactly where flamegraphs shine! 
-
 
 #### Using flamegraphs for debugging customer complaints
 Let’s assume you work in a team fully focused on improving the performance of your company’s product. While doing your normal morning routine, you notice an escalation from customer support. A customer just reported an unusual delay in load time. Looking at your graph, you notice a spike in latency in the US-east region. In the course of your investigation, you begin to notice the problem goes even deeper in the stack.

--- a/blog/what-is-continuous-profiling.mdx
+++ b/blog/what-is-continuous-profiling.mdx
@@ -34,6 +34,7 @@ While continuous profiling is new to many, the concept is actually relatively ol
 Since then, many major performance monitoring solutions have joined them in releasing continuous profiling products. As time has gone on, the continuous profiling space has been getting increasingly popular as various companies/VCs are more frequently making major investments in Continuous Profiling to keep up with demand for this type of monitoring.
 
 ![continuous profiling trends](https://user-images.githubusercontent.com/29557702/165291672-88805173-4bf4-4029-9b6c-3b31951733bd.png)
+<!--truncate-->
 
 It’s not just major cloud providers and venture capitalists who are excited about continuous profiling, our industry leaders are super pumped about continuous profiling too! 
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -190,6 +190,8 @@ module.exports = {
         blog: {
           showReadingTime: true,
           editUrl: 'https://github.com/pyroscope-io/docs/edit/main/',
+          blogSidebarTitle: 'All posts',
+          blogSidebarCount: 'ALL',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.scss'),


### PR DESCRIPTION
This adds a blog post about how to embed a flamegraph in your website. 

I also made a couple other small tweaks to the way that our blog shows up:
1. I added `truncate` to make it so that blog posts are truncated on the view where you can just scroll through blog posts
2. I made our blog show _all_ blog posts instead of the most recent ones