### PR TITLE
Fix brew command to start pyroscope server

### DIFF
--- a/docs/server-install-macos.mdx
+++ b/docs/server-install-macos.mdx
@@ -28,7 +28,7 @@ To find out about other ways of installing Pyroscope, or to find packages for ot
 To start pyroscope server and register it to launch at login (on boot), run the following command:
 
 ```shell
-brew services start pyroscope-server
+brew services start pyroscope
 ```
 
 ## Verify the installation


### PR DESCRIPTION
I was able to successfully install Pyroscope with `brew install pyroscope-io/brew/pyroscope` but when I ran the command `brew services start pyroscope-server` to start the service, I got this:
```
$ brew services start pyroscope-server
==> Tapping homebrew/services
Cloning into '/opt/homebrew/Library/Taps/homebrew/homebrew-services'...
remote: Enumerating objects: 2090, done.
remote: Total 2090 (delta 0), reused 0 (delta 0), pack-reused 2090
Receiving objects: 100% (2090/2090), 584.66 KiB | 2.63 MiB/s, done.
Resolving deltas: 100% (927/927), done.
Tapped 1 command (45 files, 739.1KB).
Error: No available formula with the name "pyroscope-server". Did you mean pyroscope?
$
```

By comparison, `brew services start pyroscope` worked just fine and the HTTP server is running:
```
$ brew services start pyroscope
==> Successfully started `pyroscope` (label: homebrew.mxcl.pyroscope)
$
```