### PR TITLE
fix: react-menu for flamegraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.13",
     "@mdx-js/react": "^1.5.8",
-    "@pyroscope/flamegraph": "0.32.2",
+    "@pyroscope/flamegraph": "0.33.0-1755-fba6d7b.0",
     "canvas-confetti": "^1.3.3",
     "clsx": "^1.1.1",
     "docusaurus-gtm-plugin": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,10 +1753,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.20.tgz#111b5db0f501aa89b05076fa31f0ea0e0c292cd3"
   integrity sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q==
 
-"@pyroscope/flamegraph@0.32.2":
-  version "0.32.2"
-  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.32.2.tgz#b82fd7e6997875d4de213fb1bc90fe4ed70c2855"
-  integrity sha512-LsVi4G5IliyffqjjlNNPYw04c3kCytLIOKew5P98nCEmjV3XinPlCu+cI/IOZVRJ2bE0q3mSWiQ7uupexYCNIA==
+"@pyroscope/flamegraph@0.33.0-1755-fba6d7b.0":
+  version "0.33.0-1755-fba6d7b.0"
+  resolved "https://registry.yarnpkg.com/@pyroscope/flamegraph/-/flamegraph-0.33.0-1755-fba6d7b.0.tgz#fbdb6c22e09d371fc73ad9062bb8ab1fc03a498f"
+  integrity sha512-sfJ+L5MwuLVSK+2K6EGlfD6W9INoFTlmPVYjYCmSDwekUq8Dnpuuc+degQulVuOnxNTFv8+cJrGTo/RW6e1QJg==
 
 "@sideway/address@^4.1.0":
   version "4.1.2"


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1611

## Changes
- issue fixed by upgrading version of react-menu in flamegraph package. This PR uses temp version flamegraph (`@pyroscope/flamegraph => 0.33.0-1755-fba6d7b.0`). Before merging this PR we need to sort out with PR which fixes this issue https://github.com/pyroscope-io/pyroscope/pull/1755