### PR TITLE
docs: add a note about retention policy lag

### DIFF
--- a/docs/retention.mdx
+++ b/docs/retention.mdx
@@ -10,6 +10,11 @@ keywords: [ pyroscope, retention, policy, configuration, downsampling ]
 By default, Pyroscope stores data indefinitely without any downsampling, which can create storage concerns.
 Pyroscope offers two complementary approaches to manage data retention.
 
+:::info
+Pyroscope server does not delete data from the disk immediately to avoid excessive disk IO, therefore you may observe
+that the disk usage continues growing even when a retention policy is enforced. Typically, the lag does not exceed 1-3 GB.
+:::
+
 ## Time-based retention policy
 
 You can configure a specific period of time for which data will be stored in the Pyroscope configuration file. For example:


### PR DESCRIPTION
To address question related to increasing disk usage even after configuring a retention policy ([example](https://pyroscope.slack.com/archives/C01FJRYENPQ/p1676271961331319))