### PR TITLE
fix: remove old description for java env PYROSCOPE_PUSH_QUEUE_CAPACITY

### DIFF
--- a/docs/integration-java.mdx
+++ b/docs/integration-java.mdx
@@ -105,7 +105,6 @@ Java integration supports JFR format to be able to support multiple events (JFR 
 * `PYROSCOPE_PROFILER_EVENT` sets the profiler event. With JFR format enabled, this event refers to one of the possible CPU profiling events: `itimer`, `cpu`, `wall`. The default is `itimer`.
 * `PYROSCOPE_PROFILER_ALLOC` sets the allocation threshold to register the events, in bytes (equivalent to `--alloc=` in `async-profiler`). The default value is "" - empty string, which means that allocation profiling is disabled. Setting it to `0` will register all the events.
 * `PYROSCOPE_PROFILER_LOCK` sets the lock threshold to register the events, in nanoseconds (equivalent to `--lock=` in `async-profiler`). The default value is "" - empty string, which means that lock profiling is disabled. Setting it to `0` will register all the events.
-* `PYROSCOPE_PUSH_QUEUE_CAPACITY` sets the default pyroscope exporter push queue capacity. The default value is 32 snapshots.
 * `PYROSCOPE_CONFIGURATION_FILE` sets an additional properties configuration file. The default value is `pyroscope.properties`.
 * `PYROSCOPE_LABELS` sets static labels in the form of comma separated `key=value` pairs. The default value is `""` - enpty string, no labels.
 


### PR DESCRIPTION
It seems the description of java env `PYROSCOPE_PUSH_QUEUE_CAPACITY` has been updated, so remove the old one. @korniltsev 