### PR TITLE
docs: Update grafana plugin related docs to point at new plugin

### DIFF
--- a/blog/visualize-flamegraph-in-grafana.mdx
+++ b/blog/visualize-flamegraph-in-grafana.mdx
@@ -22,6 +22,12 @@ authors:
 tags: [observability, flamegraphs, profiling, grafana]
 ---
 
+:::warning
+Pyroscope is now part of Grafana Labs! As a result we have consolidated efforts around our Grafana plugins to make _one_ recomended way of using Pyroscope. 
+As a result this blogpost is now outdated. **However, you can find updated docs on how to add profiling to Grafana with Pyroscope using the [Grafana profiling
+documentation](https://grafana.com/docs/grafana/latest/datasources/phlare/).**
+:::
+
 Grafana is an open-source observability and monitoring platform used by individuals and organizations to monitor their applications and infrastructures. Grafana leverages the three pillars of observability, metrics, logs, and traces, to deliver insights into how well your systems are doing. Nowadays, Observability involves a whole lot more than metrics, logs, and tracing; it also involves profiling.
 
 In this article, I will:

--- a/docs/grafana-plugins.mdx
+++ b/docs/grafana-plugins.mdx
@@ -7,77 +7,10 @@ slug: /grafana-plugins
 
 Grafana plugins allow to add pyroscope flamegraph to your Grafana dashboard.
 
-![Grafana dashboard example](/img/docs/grafana-plugins/dashboard.jpeg)
+There is now a native Flamegraph visualization in Grafana and the [Phlare datasource](https://grafana.com/docs/grafana/latest/datasources/phlare/)
+has been updated to work with both Pyroscope as a backend. 
 
-## Installation Guide
-1. Install the [panel plugin](https://grafana.com/grafana/plugins/pyroscope-panel/)
-2. Install the [datasource plugin](https://grafana.com/grafana/plugins/pyroscope-datasource/)
-3. Open Grafana and go to **Configuratin -> Plugins**
-4. Check that plugins are available
-5. Set up data source plugin:
-   * **Configuration -> Data Sources -> Add data source**
-   * click on `pyroscope-datasource`
-   * Specify Pyroscope host in `Endpoint` field:
-      ![endpoint](/img/docs/grafana-plugins/endpoint.jpeg)
-6. Set up panel plugin:
-    * Add an empty panel on your dashboard
-    * Select `pyroscope-panel` from Visualization list
-    * Under panel view in Query tab select `pyroscope-datasource`
-    * In `Application name` input specify app name
-    * Click `Apply`
-   ![settings](/img/docs/grafana-plugins/settings.jpeg)
+Please see the [Phlare datasource](https://grafana.com/docs/grafana/latest/datasources/phlare/) documentation for more information on how to add
+Pyroscope profiles to your Grafana instance. 
 
-Congratulations! Now you can monitor application flamegraph on your Grafana dashboard!
-![dashboard](/img/docs/grafana-plugins/dashboard.jpeg)
-
-## Running latest plugin versions
-Grafana plugin approval takes some time, so if you want to run the latest versions you can do by:
-
-Running grafana with the `GF_INSTALL_PLUGINS` environment variable with (broken in 2 lines for readability:)
-```
-https://github.com/pyroscope-io/grafana-panel-plugin/releases/download/v1.1.0/pyroscope-panel-1.1.0.zip;pyroscope-panel,
-https://github.com/pyroscope-io/grafana-datasource-plugin/releases/download/v1.1.0/pyroscope-datasource-1.1.0.zip;pyroscope-datasource
-```
-
-You can get the correct URLS by looking at our releases in the [grafana-datasource-plugin repo](https://github.com/pyroscope-io/grafana-datasource-plugin/releases) and the [grafana-panel-plugin repo](https://github.com/pyroscope-io/grafana-panel-plugin/releases)
-
-For example:
-```
-GF_INSTALL_PLUGINS=https://github.com/pyroscope-io/grafana-panel-plugin/releases/download/v1.1.0/pyroscope-panel-1.1.0.zip;pyroscope-panel,https://github.com/pyroscope-io/grafana-datasource-plugin/releases/download/v1.1.0/pyroscope-datasource-1.1.0.zip;pyroscope-datasource
-
-```
-
-## Using variables
-Since version `1.1.0` of the `pyroscope-datasource` we support querying using variables.
-
-
-For example:
-![query variables](/img/docs/grafana-plugins/variables.png)
-
-
-## Using authentication
-:::note
-This functionality is available starting from 
-* pyroscope version 0.10.0
-* datasource plugin version 1.1.3
-
-Make sure to upgrade before you use this.
-:::
-
-If you have user authentication enabled in the pyroscope server, you will also need to create an API key (`ReadOnly` role is sufficient) and specify it in the datasource configuration:
-
-1. [Create an API Key](/docs/api-key-authentication)
-2. In the pyroscope datasource config add the **API KEY**. If you are using [config file provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/) the configuration will look like this:
-
-```yaml
-apiVersion: 1
-datasources:
-  - name: Pyroscope
-    type: pyroscope-datasource
-    access: proxy
-    uid: pyroscope
-    jsonData:
-      path: http://pyroscope:4040
-    secureJsonData:
-      apiKey: MY_API_KEY
-```
+![image](https://github.com/pyroscope-io/docs/assets/23323466/a4854991-9019-431e-bbfe-ce93d66ce5b2)


### PR DESCRIPTION
Now that we merged with Grafana we are consolidating efforts. This PR points our docs to Grafana instead of having people install our deprecated plugins